### PR TITLE
Update config.ru to allow no redirects

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -71,7 +71,7 @@ class Redirects < BaseMiddleware
     ext  = File.extname(path)
     path += '/' if ext == '' and ! path.end_with?('/')
 
-    if redirect = CONFIG['redirects'].find{|x| path == x['from']}
+    if CONFIG['redirects'] and redirect = CONFIG['redirects'].find{|x| path == x['from']}
       new_location = redirect['to']
       new_location = request.base_url + new_location \
         unless new_location.start_with?("http")


### PR DESCRIPTION
When you don't add anything to redirects in _config.yml, localhost:9292 throws an error because CONFIG['redirects'] is nil.
