### PR TITLE
Fix a typo in Scala-best-practices

### DIFF
--- a/source/blog/2014-10-20-scala-best-practices.markdown.erb
+++ b/source/blog/2014-10-20-scala-best-practices.markdown.erb
@@ -447,7 +447,7 @@ defeats the purpose of using Option.
 Avoid using Any or AnyRef or explicit casting, unless you've got a
 really good reason for it. Scala is a language that derives value from
 its expressive type system, usage of Any or of typecasting represents
-a whole in this expressive type system and the compiler doesn't know
+a hole in this expressive type system and the compiler doesn't know
 how to help you there. In general, something like this is bad:
 
 ```scala


### PR DESCRIPTION
whole -> hole
